### PR TITLE
Add order number to URL of new order notification link.

### DIFF
--- a/classes/class-wc-pushover.php
+++ b/classes/class-wc-pushover.php
@@ -352,7 +352,8 @@ class WC_Pushover extends WC_Integration {
 					$this->pushover_get_currency_symbol() . $order_total
 				);
 
-				$url     = get_admin_url();
+				//2018-07-19 - JB add order number to URL
+				$url     = get_admin_url().'post.php?post='.$order_id.'&action=edit';
 
 				$args = array(
 					'title'    => $title,


### PR DESCRIPTION
I made a small revision to add the order ID to notification URLs, so that they click through to the actual order instead of the admin dashboard.