### PR TITLE
Issue 26 - Add filter

### DIFF
--- a/classes/class-wc-pushover.php
+++ b/classes/class-wc-pushover.php
@@ -592,7 +592,7 @@ class WC_Pushover extends WC_Integration {
 			);
 		}
 
-		return $custom_string;
+		return apply_filters( 'pushover_custom_message_string', $custom_string );
 
 	}
 


### PR DESCRIPTION
## Description

Add filter to return of `WC_Pushover::replace_fields_custom_message()`

## Testing

Tested on local and iPhone X. 
Test messages and live message worked.

Test code added to theme's `functions.php`:
```php
function testing_the_thing( $message ) {
	return 'this is the new message';
}
add_filter('wc_pushover_custom_message_string','testing_the_thing');

```

Message received:
<img width="391" alt="iphone" src="https://user-images.githubusercontent.com/290886/130259706-6b95fcc3-ab51-49e0-9c92-496db74f57c8.png">

