### PR TITLE
Issue 24

### DIFF
--- a/classes/class-pushover-api.php
+++ b/classes/class-pushover-api.php
@@ -28,6 +28,8 @@ class Pushover_Api {
 	private $user_api = '';
 	private $device   = '';
 	private $priority = '';
+	private $retry    = '';
+	private $expire   = '';
 	private $sound    = '';
 	private $title    = '';
 	private $message  = '';
@@ -112,6 +114,40 @@ class Pushover_Api {
 	}
 
 	/**
+	 * Set the retry (in seconds) parameter for Emergency priority messages
+	 * @param $retry
+	 */
+	public function setRetry( $retry ) {
+		$this->retry = $retry;
+	}
+
+	/**
+	 * Get retry to send to Pushover (optional)
+	 *
+	 * @return string $retry
+	 */
+	public function getRetry() {
+		return $this->retry;
+	}
+
+	/**
+	 * Set the Expire (in seconds) parameter for Emergency priority messages
+	 * @param $expire
+	 */
+	public function setExpire( $expire ) {
+		$this->expire = $expire;
+	}
+
+	/**
+	 * Get Expire to send to Pushover (optional)
+	 *
+	 * @return string $expire
+	 */
+	public function getExpire() {
+		return $this->expire;
+	}
+
+	/**
 	 *  Set Sound to send to Pushover (optional)
 	 *
 	 */
@@ -122,7 +158,7 @@ class Pushover_Api {
 	/**
 	 * Get Sound to send to Pushover (optional)
 	 *
-	 * @return string $priority
+	 * @return string $sound
 	 */
 	public function getSound() {
 		return $this->sound;
@@ -203,6 +239,9 @@ class Pushover_Api {
 			'message' => $this->message,
 			'url'     => $this->url,
 			'sound'   => $this->sound,
+			'priority'=> $this->priority,
+			'retry'   => $this->retry,
+			'expire'  => $this->expire,
 		);
 
 		$response = wp_remote_post(

--- a/classes/class-wc-pushover.php
+++ b/classes/class-wc-pushover.php
@@ -203,6 +203,26 @@ class WC_Pushover extends WC_Integration {
 				),
 				'default'     => '0',
 			),
+			'retry' => array(
+				'title'             => __( 'Retry', 'wc_pushover' ),
+				'description'       => __( 'How often (in seconds) Pushover servers will send notification to the user until the message is acknowledged by the user.<br/>This is only used if Priority is set to <code>2 Emergency Priority</code>.<br/>Example: <code>30</code> to resend message every 30 seconds.', 'wc_pushover' ),
+				'placeholder'       => 30,
+				'type'              => 'number',
+				'default'           => '',
+                'custom_attributes' => array(
+                        'min' => '30',
+                ),
+            ),
+			'expire' => array(
+				'title'             => __( 'Expire', 'wc_pushover' ),
+				'description'       => __( 'How many seconds your notification will continue to be retried (for every `retry` seconds).<br/>This is only used if Priority is set to <code>2 Emergency Priority</code>.<br/>Example: <code>3600</code> to send the message every <code>retry</code> seconds for 1 hour.', 'wc_pushover' ),
+				'placeholder'       => 3600,
+                'type'              => 'number',
+				'default'           => '',
+                'custom_attributes' => array(
+                        'max' => '10800',
+                ),
+            ),
 			'sound'              => array(
 				'title'       => __( 'Notification Sound', 'wc_pushover' ),
 				'description' => sprintf(

--- a/classes/class-wc-pushover.php
+++ b/classes/class-wc-pushover.php
@@ -50,6 +50,9 @@ class WC_Pushover extends WC_Integration {
 	 */
 	public $priority = '';
 
+	public $retry = '';
+
+	public $expire = '';
 	/**
 	 * desc
 	 *
@@ -122,6 +125,8 @@ class WC_Pushover extends WC_Integration {
 		$this->user_api = isset( $this->settings['user_api'] ) ? $this->settings['user_api'] : '';
 		$this->device   = isset( $this->settings['device'] ) ? $this->settings['device'] : '';
 		$this->priority = isset( $this->settings['priority'] ) ? $this->settings['priority'] : '';
+		$this->retry    = isset( $this->settings['retry'] ) ? $this->settings['retry'] : '';
+		$this->expire   = isset( $this->settings['expire'] ) ? $this->settings['expire'] : '';
 		$this->debug    = isset( $this->settings['debug'] ) && 'yes' === $this->settings['debug'] ? true : false;
 		$this->sound    = isset( $this->settings['sound'] ) ? $this->settings['sound'] : '';
 
@@ -668,6 +673,8 @@ class WC_Pushover extends WC_Integration {
 			$pushover->setDevice( $this->device );
 		}
 		$pushover->setPriority( $this->priority );
+		$pushover->setRetry( $this->retry );
+		$pushover->setExpire( $this->expire );
 		$pushover->setSound( $this->sound );
 
 		// Setup message


### PR DESCRIPTION
## Description

This PR adds a "retry" and "expire" setting so the plugin will send these parameters to Pushover's servers to be used in conjunction with the Emergency message priority.

Closes #24.

## Testing
I added retry of 30 seconds and expire of 3600 seconds:
<img width="709" alt="Screen Shot 2021-08-20 at 11 46 00 AM" src="https://user-images.githubusercontent.com/290886/130266708-efaae609-ad99-43d4-a78e-e046e0dd411f.png">

I set the priority to 2 and placed an order. I received the emergency notification that required acknowledgement to go away:
<img width="448" alt="testing" src="https://user-images.githubusercontent.com/290886/130269495-104fcc3a-0a07-417e-b6eb-a26bd6417c38.png">

